### PR TITLE
Add Debug Maze Generation to Prims

### DIFF
--- a/Projects/Maze/Prims/Graph.cs
+++ b/Projects/Maze/Prims/Graph.cs
@@ -31,5 +31,53 @@ namespace Prims
 		{
 			Nodes = nodes ?? throw new ArgumentNullException(nameof(nodes));
 		}
+
+		public static Maze.Tile[,] ConvertToGrid(Graph graph, int rows, int columns, Func<int, int, int> index, int start_row, int start_column, int end_row, int end_column)
+		{
+			var tiles = new Maze.Tile[rows, columns];
+
+			foreach (var node in graph.Nodes)
+			{
+				if (node == null)
+					continue;
+
+				(int, int) Unpack(int i) => (i % rows, i / rows);
+
+				var (row, col) = Unpack(node.OwnIndex);
+
+				// directional
+				if (node.Connections.Contains(index(row - 1, col)))
+				{
+					tiles[row, col] |= Maze.Tile.Up;
+					tiles[row - 1, col] |= Maze.Tile.Down;
+				}
+				if (node.Connections.Contains(index(row + 1, col)))
+				{
+					tiles[row, col] |= Maze.Tile.Down;
+					tiles[row + 1, col] |= Maze.Tile.Up;
+				}
+				if (node.Connections.Contains(index(row, col - 1)))
+				{
+					tiles[row, col] |= Maze.Tile.Left;
+					tiles[row, col - 1] |= Maze.Tile.Right;
+				}
+				if (node.Connections.Contains(index(row, col + 1)))
+				{
+					tiles[row, col] |= Maze.Tile.Right;
+					tiles[row, col + 1] |= Maze.Tile.Left;
+				}
+
+				// start/end
+				if (row == start_row && col == start_column)
+				{
+					tiles[row, col] |= Maze.Tile.Start;
+				}
+				if (row == end_row && col == end_column)
+				{
+					tiles[row, col] |= Maze.Tile.End;
+				}
+			}
+			return tiles;
+		}
 	}
 }

--- a/Projects/Maze/Prims/PrimsAlgorithm.cs
+++ b/Projects/Maze/Prims/PrimsAlgorithm.cs
@@ -5,55 +5,6 @@ namespace Prims
 {
 	public static class PrimsAlgorithm
 	{
-		private readonly struct TwoWayConnection : IComparable<TwoWayConnection>
-		{
-			public readonly int IndexA;
-			public readonly int IndexB;
-			public readonly double Cost;
 
-			public TwoWayConnection(int indexA, int indexB, double cost)
-			{
-				IndexA = indexA;
-				IndexB = indexB;
-				Cost = cost;
-			}
-
-			public int CompareTo(TwoWayConnection other) => other.Cost.CompareTo(Cost); // inversed because of how the heap works
-		}
-
-		public static Graph SimplePrims(Graph graph)
-		{
-			var newGraph = new Graph(new Graph.Node[graph.Nodes.Length]);
-			var nodes = graph.Nodes;
-			var current = nodes[0];
-			newGraph.Nodes[0] = new Graph.Node(0);
-
-			var heap = new HeapArray<TwoWayConnection>();
-
-			while (true)
-			{
-				for (int i = 0; i < current.Connections.Count; i++)
-				{
-					heap.Enqueue(new TwoWayConnection(current.OwnIndex, current.Connections[i], current.Costs[i]));
-				}
-
-				TwoWayConnection c;
-				do
-				{
-					if (heap.Count == 0)
-					{
-						return newGraph;
-					}
-					c = heap.Dequeue();
-				}
-				while (newGraph.Nodes[c.IndexB] != null);
-
-				newGraph.Nodes[c.IndexA].Add(c.IndexB, c.Cost);
-
-				newGraph.Nodes[c.IndexB] = new Graph.Node(c.IndexB);
-				current = graph.Nodes[c.IndexB];
-				newGraph.Nodes[c.IndexB].Add(c.IndexA, c.Cost);
-			}
-		}
 	}
 }


### PR DESCRIPTION
For now a using directive is placed in `Prims/PrimsMazeGenerator.cs`.
Works quite nicely, didn't expect that.
Fixes #8

<details>
  <summary>Some Images</summary>

![image](https://user-images.githubusercontent.com/22711887/75622698-89ec8f00-5ba3-11ea-918d-7f99d4157369.png)
![image](https://user-images.githubusercontent.com/22711887/75622702-91ac3380-5ba3-11ea-9145-9e21aaa88a41.png)
![image](https://user-images.githubusercontent.com/22711887/75622704-9d97f580-5ba3-11ea-9e64-1c646c853dce.png)
![image](https://user-images.githubusercontent.com/22711887/75622706-a5579a00-5ba3-11ea-92bd-d2f1ccc9e601.png)
![image](https://user-images.githubusercontent.com/22711887/75622709-b0122f00-5ba3-11ea-8f3a-da9ad5e7bfe5.png)
![image](https://user-images.githubusercontent.com/22711887/75622713-bd2f1e00-5ba3-11ea-98f4-cefb191e64d4.png)

</details>