### PR TITLE
corrected issue Status: Open. #28

### DIFF
--- a/Projects/Tanks/Program.cs
+++ b/Projects/Tanks/Program.cs
@@ -155,22 +155,37 @@ while (Tanks.Contains(Player) && Tanks.Count > 1)
 
 		if (tank.IsShooting)
 		{
-			tank.Bullet = new Bullet()
+			// Calculate the potential bullet position
+			int bulletX = tank.Direction switch
 			{
-				X = tank.Direction switch
-				{
-					Direction.Left => tank.X - 3,
-					Direction.Right => tank.X + 3,
-					_ => tank.X,
-				},
-				Y = tank.Direction switch
-				{
-					Direction.Up => tank.Y - 2,
-					Direction.Down => tank.Y + 2,
-					_ => tank.Y,
-				},
-				Direction = tank.Direction,
+				Direction.Left => tank.X - 3,
+				Direction.Right => tank.X + 3,
+				_ => tank.X,
 			};
+			int bulletY = tank.Direction switch
+			{
+				Direction.Up => tank.Y - 2,
+				Direction.Down => tank.Y + 2,
+				_ => tank.Y,
+			};
+
+			// Create a temporary bullet to check for collision
+			var tempBullet = new Bullet
+			{
+				X = bulletX,
+				Y = bulletY,
+				Direction = tank.Direction
+			};
+
+			// Check if the bullet would spawn in a wall
+			bool initialCollision = BulletCollisionCheck(tempBullet, out _);
+
+			// Only create the bullet if there's no initial collision
+			if (!initialCollision)
+			{
+				tank.Bullet = tempBullet;
+			}
+
 			tank.IsShooting = false;
 			continue;
 		}


### PR DESCRIPTION
**Issue**  
Fixed a bug where bullets could pass through walls when tanks were positioned directly adjacent to them.  
This occurred because no collision detection was performed when bullets were initially spawned. If a tank was placed right next to a wall and fired, the bullet would appear on the other side of the wall boundary.

**Changes Made**
- Added collision detection at bullet creation time.
- Created a temporary bullet object to validate the spawn position before actual creation.
- Bullets are now only spawned if the initial position does not result in a collision.

**Before**
![Screenshot 2025-04-21 012403](https://github.com/user-attachments/assets/7a613306-4d6c-4290-b0b6-242d4da33dbf)

**After**
![Screenshot 2025-04-21 014148](https://github.com/user-attachments/assets/78b85448-8e21-4daf-8a29-79c820fdbd18)
